### PR TITLE
Sort events by endDate on fetch

### DIFF
--- a/src/utils/getAllEvents.ts
+++ b/src/utils/getAllEvents.ts
@@ -6,17 +6,30 @@ import type { EventPost } from '@/interfaces'
 
 export const getAllEvents = (fs: any): EventPost[] => {
   const eventFiles: string[] = fs.readdirSync(EVENTS_DIR)
-  return eventFiles.map((file) => {
-    // Read markdown file as string
-    const fullPath = path.join(EVENTS_DIR, file)
-    const fileContents = fs.readFileSync(fullPath, 'utf8')
-    // Use gray-matter to parse the post metadata section
-    const { data: frontmatter, content } = matter(fileContents, MATTER_OPTIONS)
-    const url: string = `${EVENTS_PATH}/${file.replace(/\.md$/, '')}`
-    return {
-      frontmatter,
-      content: sanitizePostPreviewContent(content),
-      url,
-    } as EventPost
-  })
+  return (
+    eventFiles
+      .map((file) => {
+        // Read markdown file as string
+        const fullPath = path.join(EVENTS_DIR, file)
+        const fileContents = fs.readFileSync(fullPath, 'utf8')
+        // Use gray-matter to parse the post metadata section
+        const { data: frontmatter, content } = matter(
+          fileContents,
+          MATTER_OPTIONS
+        )
+        const url: string = `${EVENTS_PATH}/${file.replace(/\.md$/, '')}`
+        return {
+          frontmatter,
+          content: sanitizePostPreviewContent(content),
+          url,
+        } as EventPost
+      })
+      // Sort newest first
+      .sort((a, b) =>
+        new Date(a.frontmatter.endDate).getTime() >
+        new Date(b.frontmatter.endDate).getTime()
+          ? -1
+          : 1
+      )
+  )
 }


### PR DESCRIPTION
## Description

Adds a sort function to the events when being fetched using `utils/getAllEvents.ts`.

Results in the most recent past events being listed first in the homepage preview. 