### PR TITLE
Apply max-width to text element instead of container

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,12 +100,13 @@ export default function Home({
             alignItems="start"
             maxW="container.lg"
           >
-            <Box fontSize="2xl" maxW="8ch">
+            <Box fontSize="2xl">
               <Text
                 fontFamily="mono"
                 color="primary"
                 lineHeight="130%"
                 fontSize="inherit"
+                maxW="8ch"
               >
                 Solidity {versionNumber}
               </Text>


### PR DESCRIPTION
**Description**

This PR addresses an overflow issue caused by setting the max-width to 8ch on the container, which does not account for variable font widths. When a font-face with a larger width is used, this can lead to unwanted overflow.

**Changes:**

- Removed max-width from container.
- Applied max-width directly to text element.

**Screenshot**

![image](https://github.com/ethereum/solidity-website/assets/62268199/354b8bc9-d4d6-4ebc-8a98-8439385732fc)
