### PR TITLE
Change link for Solidity Summit 2023 to Devconnect page

### DIFF
--- a/src/events/solidity-summit-2023.md
+++ b/src/events/solidity-summit-2023.md
@@ -6,5 +6,5 @@ endDate: 2023-11-16
 imageSrc: /assets/solidity_summit_2023.png
 links:
   - label: Join us
-    href: https://summit.soliditylang.org
+    href: https://devconnect.org/schedule
 ---


### PR DESCRIPTION
We'll direct to https://devconnect.org/schedule until we have updated summit.soliditylang.org