### PR TITLE
Blog post: cap width and center [Fixes #15]

### DIFF
--- a/src/pages/blog/[YYYY]/[MM]/[DD]/[post].tsx
+++ b/src/pages/blog/[YYYY]/[MM]/[DD]/[post].tsx
@@ -54,7 +54,13 @@ const BlogPostPage: React.FC<BlogPostProps> = ({
       title={frontmatter.title}
       description={getBlogSubtitle(frontmatter.author, frontmatter.date)}
     />
-    <Box as="main" id={MAIN_CONTENT_ID} px={{ base: 4, md: 8 }}>
+    <Box
+      as="main"
+      id={MAIN_CONTENT_ID}
+      px={{ base: 4, md: 8 }}
+      maxW="container.md"
+      mx="auto"
+    >
       <BlogHero frontmatter={frontmatter} />
       <BlogPost content={content} maxW="container.md" />
       <PostNavigation availableURLs={availableURLs} />


### PR DESCRIPTION
Centers content and hero for blog posts.

<img width="1381" alt="image" src="https://github.com/ethereum/solidity-website/assets/54227730/9ef3ad89-22af-4543-a826-12d3da241299">

<img width="793" alt="image" src="https://github.com/ethereum/solidity-website/assets/54227730/5c326269-26b7-4145-b380-133741db61cd">
