### PR TITLE
Update GitHub project link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -139,7 +139,7 @@ export default function Home({
               approximately one breaking release per year. You can follow the
               implementation status of new features in the{' '}
               <Link
-                href="https://github.com/ethereum/solidity/projects/17"
+                href="https://github.com/orgs/ethereum/projects/26"
                 fontWeight="bold"
               >
                 Solidity GitHub project


### PR DESCRIPTION
This PR updates the link in the "Solidity is evolving rapidly" section of the homepage to point to a current GitHub project board. The current copy reads like this:

> **Solidity is evolving rapidly**
> We aim for a regular (non-breaking) release every month, with approximately one breaking release per year. You can follow the implementation status of new features in the [Solidity GitHub project](https://github.com/ethereum/solidity/projects/17).

Currently, the link [goes to an old project from 2018 called "Coinspect Audit"](https://github.com/ethereum/solidity/projects/17).

This PR updates the link so it goes to ["Solidity Roadmap"](https://github.com/orgs/ethereum/projects/26).