### PR TITLE
Use internal link for blog callout

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -4,7 +4,7 @@ import {
   useColorMode,
 } from '@chakra-ui/react'
 import NextLink from 'next/link'
-import { DOCS_URL } from '@/constants'
+import { BLOG_PATH, DOCS_URL, OLD_BLOG_SUBDOMAIN } from '@/constants'
 interface LinkComponentProps extends LinkProps {
   hideArrow?: boolean
 }
@@ -22,8 +22,9 @@ export const Link: React.FC<LinkComponentProps> = ({
       color: 'primary',
     },
   }
+  const isBlogSubdomain = href.startsWith(OLD_BLOG_SUBDOMAIN)
   const isDoc = href.startsWith(DOCS_URL)
-  const isExternal = href.startsWith('http') && !isDoc
+  const isExternal = href.startsWith('http') && !isDoc && !isBlogSubdomain
 
   if (isExternal)
     return (
@@ -50,6 +51,8 @@ export const Link: React.FC<LinkComponentProps> = ({
     params.set('color', colorMode)
     url.search = params.toString()
     path = url.toString()
+  } else if (isBlogSubdomain) {
+    path = BLOG_PATH + new URL(href).pathname
   }
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,6 +78,7 @@ export const PAGE_PATH = '/page' as const
 export const BLOG_PAGE_PATH = `${BLOG_PATH}${PAGE_PATH}` as const
 export const CATEGORY_PATH = '/category' as const
 export const BLOG_CATEGORY_PATH = `${BLOG_PATH}${CATEGORY_PATH}` as const
+export const OLD_BLOG_SUBDOMAIN = 'https://blog.soliditylang.org/' as const
 
 // Blog categories and mappings
 export const RELEASES = 'Releases' as const

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -115,7 +115,7 @@ export default function Home({
               <Box>
                 <Text lineHeight="180%" fontSize="md" mb={4}>
                   <Link
-                    href="https://blog.soliditylang.org/2023/07/19/solidity-0.8.21-release-announcement/"
+                    href="https://soliditylang.org/blog/2023/07/19/solidity-0.8.21-release-announcement/"
                     fontWeight="bold"
                   >
                     Solidity 0.8.21

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -115,7 +115,7 @@ export default function Home({
               <Box>
                 <Text lineHeight="180%" fontSize="md" mb={4}>
                   <Link
-                    href="https://soliditylang.org/blog/2023/07/19/solidity-0.8.21-release-announcement/"
+                    href="/blog/2023/07/19/solidity-0.8.21-release-announcement/"
                     fontWeight="bold"
                   >
                     Solidity 0.8.21


### PR DESCRIPTION
Our homepage currently uses the 'blog.soliditylang.org' link. This is recognized as an external link, which triggers a complete page refresh and opens in a new tab.

In this PR, I've updated the link to use 'soliditylang.org/blog/', the recognized internal link. This should avoid the page reloading and provide a smoother user experience.