### PR TITLE
Remove indentation on mobile footer links [Fixes #16]

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -37,7 +37,7 @@ export const Footer: React.FC = () => (
         direction={{ base: 'column', md: 'row' }}
       >
         {NAV_LINKS.map(({ name, href }) => (
-          <Link key={name} href={href} textDecoration="none" py={1} px={2}>
+          <Link key={name} href={href} textDecoration="none" py={1} px={{ base: 0, md: 2 }}>
             {name}
           </Link>
         ))}


### PR DESCRIPTION
## Description
Removes the inline-padding used on footer links on mobile. Not needed when links stack vertically.

## Related issue
- Fixes #16