### PR TITLE
Update Solidity Summit 2023 Card to point to summit.soliditylang.org

### DIFF
--- a/src/events/solidity-summit-2023.md
+++ b/src/events/solidity-summit-2023.md
@@ -6,5 +6,5 @@ endDate: 2023-11-16
 imageSrc: /assets/solidity_summit_2023.png
 links:
   - label: Join us
-    href: https://devconnect.org/schedule
+    href: https://summit.soliditylang.org/
 ---


### PR DESCRIPTION
I updated https://summit.soliditylang.org/ to a 2023 "coming soon" stage so I believe we can add the link back into the main page. :)