### PR TITLE
Force non-emoji unicode arrow [Fixes #6]

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -35,7 +35,7 @@ export const Link: React.FC<LinkComponentProps> = ({
           hideArrow
             ? {}
             : {
-                content: '" ↗"',
+                content: '" ↗\uFE0E"',
                 whiteSpace: 'nowrap',
               }
         }


### PR DESCRIPTION
## Description
Adds unicode modifier to force the external link arrow to always display in the non-emoji force.

The modifier code `FE0E` (`\uFE0E` in JavaScript) can be placed after a unicode character to avoid ambiguity and force the non-emoji rendering:

<img width="619" alt="image" src="https://github.com/ethereum/solidity-website/assets/54227730/ba74beff-147a-4027-ba6f-c5660506a091">

---

The opposite can be done with `\uFE0F` which will force the emoji form:

<img width="630" alt="image" src="https://github.com/ethereum/solidity-website/assets/54227730/3182d566-88ab-406d-abe4-217114a22949">

## Related issue
- Fixes #6 