### PR TITLE
Fix typo on use cases page

### DIFF
--- a/src/pages/use-cases.tsx
+++ b/src/pages/use-cases.tsx
@@ -36,7 +36,7 @@ export default function UseCases() {
           <Text>
           If you want to get started building your own applications, head to the 
           {' '}
-                <Link href="https://docs.soliditylang.org/en/latest/solidity-by-example.html">Solidity by Example</Link>
+                <Link href="https://docs.soliditylang.org/en/latest/solidity-by-example.html">Solidity by Example</Link>{' '}
           section to see code examples of different contracts and understand the core concepts of the language.
           </Text>
         </Section>


### PR DESCRIPTION
Noticed no spacing between the link and words. Fixed in this PR.

<img width="1142" alt="Screenshot 2023-10-23 at 18 17 52" src="https://github.com/ethereum/solidity-website/assets/62268199/b293f950-2f01-4f9b-b055-d84721a1c627">
