### PR TITLE
Patch next/previous blog post navigation bug

### DIFF
--- a/src/hooks/useCleanRouterPath.ts
+++ b/src/hooks/useCleanRouterPath.ts
@@ -1,12 +1,9 @@
 import { useRouter } from 'next/router'
 
 export const useCleanRouterPath = () => {
-  const router = useRouter()
-
-  const queryIndex = router.asPath.includes('?')
-    ? router.asPath.indexOf('?')
-    : router.asPath.indexOf('#')
-  const hasParams = queryIndex > -1
-
-  return router.asPath.slice(0, hasParams ? queryIndex : undefined)
+  const { asPath } = useRouter()
+  return asPath
+    .replace(/\?[^\#]*/, "") // Remove query string
+    .replace(/\#.*/, "") // Remove hash
+    .replace(/\/$/, "") // Remove trailing slash
 }


### PR DESCRIPTION
## Description
- Updates the logic for `useCleanRouterPath` function; ensures removal of all query params, hash links, and trailing slashes
- This fixes a bug where the path of the current page had a trailing slash and was not being recognized in the ordered list of blog post pages, thus didn't know where it properly fit in the ordering.

## Related issue
Notice on the first post we still have a "Previous" button which links to `/blogundefined`, and the "Next" button takes user to the same page:
<img width="1224" alt="image" src="https://github.com/ethereum/solidity-website/assets/54227730/e4497cc4-0ad5-4bdc-89e6-2d880ce5abde">

With fix:
<img width="1183" alt="image" src="https://github.com/ethereum/solidity-website/assets/54227730/a9f46bea-90ee-4c1b-8da4-11f69b7f6792">
