### PR TITLE
Remove/patch markdown h1s

### DIFF
--- a/src/posts/2019-03-26-solidity-optimizer-and-abiencoderv2-bug.md
+++ b/src/posts/2019-03-26-solidity-optimizer-and-abiencoderv2-bug.md
@@ -19,7 +19,7 @@ All the bugs mentioned here should be easily visible in tests that touch the rel
 
 Credits to Melonport team (Travis Jacobs & Jenna Zenk) and the Melon Council (Nick Munoz-McDonald, Martin Lundfall, Matt di Ferrante & Adam Kolar), who reported this via the Ethereum bug bounty program!
 
-# Who should be concerned
+## Who should be concerned
 
 If you have deployed contracts which use the experimental ABI encoder V2, then those might be affected. This means that only contracts which use the following directive within the source code can be affected:
 
@@ -29,7 +29,7 @@ Additionally, there are a number of requirements for the bug to trigger. See tec
 
 As far as we can tell, there are about 2500 contracts live on mainnet that use the experimental ABIEncoderV2. It is not clear how many of them contain the bug.
 
-# How to check if contract is vulnerable
+## How to check if contract is vulnerable
 
 The bug only manifests itself when all of the following conditions are met:
 
@@ -44,7 +44,7 @@ In addition to that, in the following situations, your code is NOT affected:
 
 If you have a contract that meets these conditions, and want to verify whether the contract is indeed vulnerable, you can reach out to us via security@ethereum.org.
 
-# How to prevent these types of flaws in the future
+## How to prevent these types of flaws in the future
 
 In order to be conservative about changes, the experimental ABI encoder has been available only when explicitly enabled, to allow people to interact with it and test it without putting too much trust in it before it is considered stable.
 
@@ -54,38 +54,38 @@ For developers -- bugs within the Solidity compiler are difficult to detect with
 
 The best way to protect against these types of flaws is to have a rigorous set of end-to-end tests for your contracts (verifying all code paths), since bugs in a compiler very likely are not "silent" and instead manifest in invalid data.
 
-# Possible consequences
+## Possible consequences
 
 Naturally, any bug can have wildly varying consequences depending on the program control flow, but we expect that this is more likely to lead to malfunction than exploitability.
 
 The bug, when triggered, will under certain circumstances send corrupt parameters on method invocations to other contracts.
 
-# Timeline
+## Timeline
 
-#### 2019-03-16:
+### 2019-03-16:
 
 - Report via bug bounty, about corruption caused when reading from arrays of booleans directly from storage into ABI encoder.
 
-#### 2019-03-16 to 2019-03-21:
+### 2019-03-16 to 2019-03-21:
 
 - Investigation of root cause, analysis of affected contracts. An unexpectedly high count of contracts compiled with the experimental encoder were found deployed on mainnet, many without verified source-code.
 - Investigation of bug found more ways to trigger the bug, e.g. using structs. Furthermore, an array overflow bug was found in the same routine.
 - A handful of contracts found on Github were checked, and none were found to be affected.
 - A bugfix to the ABI encoder was made.
 
-#### 2019-03-20:
+### 2019-03-20:
 
 - Decision to make information public.
 - Reasoning: It would not be feasible to detect all vulnerable contracts and reach out to all authors in a timely manner, and it would be good to prevent further proliferation of vulnerable contracts on mainnet.
 
-#### 2019-03-26:
+### 2019-03-26:
 
 - New compiler release, version 0.5.7.
 - This post released.
 
-# Technical details
+## Technical details
 
-## Background
+### Background
 
 The Contract ABI is a specification how data can be exchanged with contracts from the outside (a Dapp) or when interacting between contracts. It supports a variety of types of data, including simple values like numbers, bytes and strings, as well as more complex data types, including arrays and structs.
 
@@ -93,13 +93,13 @@ When a contract receives input data, it must decode that (this is done by the "A
 
 In mid-2017 the Solidity team started to work on a fresh implementation named "ABI encoder V2" with the goal of having a more flexible, safe, performant and auditable code generator. This experimental code generator, when explicitly enabled, has been offered to users since the end of 2017 with the 0.4.19 release.
 
-## The flaw
+### The flaw
 
 The experimental ABI encoder does not handle non-integer values shorter than 32 bytes properly. This applies to `bytesNN` types, `bool`, `enum` and other types when they are part of an array or a struct and encoded directly from storage. This means these storage references have to be used directly inside `abi.encode(...)`, as arguments in external function calls or in event data without prior assignment to a local variable. Using `return` does not trigger the bug. The types `bytesNN` and `bool` will result in corrupted data while `enum` might lead to an invalid `revert`.
 
 Furthermore, arrays with elements shorter than 32 bytes may not be handled correctly even if the base type is an integer type. Encoding such arrays in the way described above can lead to other data in the encoding being overwritten if the number of elements encoded is not a multiple of the number of elements that fit a single slot. If nothing follows the array in the encoding (note that dynamically-sized arrays are always encoded after statically-sized arrays with statically-sized content), or if only a single array is encoded, no other data is overwritten.
 
-# Two unrelated bugs
+## Two unrelated bugs
 
 Unrelated to the ABI encoder issue explained above, two bugs have been found in the optimiser. Both have been introduced with 0.5.5 (released on 5th of March). They are unlikely to occur in code generated by the compiler, unless inline assembly is used.
 

--- a/src/posts/2019-06-25-solidity-storage-array-bugs.md
+++ b/src/posts/2019-06-25-solidity-storage-array-bugs.md
@@ -25,9 +25,9 @@ Both bugs should be easily visible in tests that touch the relevant code paths.
 
 Details about the two bugs can be found below.
 
-# Signed Integer Array Bug
+## Signed Integer Array Bug
 
-## Who should be concerned
+### Who should be concerned
 
 If you have deployed contracts which use signed integer arrays in storage and either directly assign
 
@@ -38,21 +38,21 @@ to it, this will lead to data corruption in the storage array.
 
 Contracts that only assign individual array elements (i.e. with `x[2] = -1;`) are not affected.
 
-## How to check if contract is vulnerable
+### How to check if contract is vulnerable
 
 If you use signed integer arrays in storage, try to run tests where you use negative values. The effect should be that the actual value stored is positive instead of negative.
 
 If you have a contract that meets these conditions, and want to verify whether the contract is indeed vulnerable, you can reach out to us via security@ethereum.org.
 
-## Technical details
+### Technical details
 
 Storage arrays can be assigned from arrays of different type. During this copy and assignment operation, a type conversion is performed on each of the elements. In addition to the conversion, especially if the signed integer type is shorter than 256 bits, certain bits of the value have to be zeroed out in preparation for storing multiple values in the same storage slot.
 
 Which bits to zero out was incorrectly determined from the source and not the target type. This leads to too many bits being zeroed out. In particular, the sign bit will be zero which makes the value positive.
 
-# ABIEncoderV2 Array Bug
+## ABIEncoderV2 Array Bug
 
-## Who should be concerned
+### Who should be concerned
 
 If you have deployed contracts which use the experimental ABI encoder V2, then those might be affected. This means that only contracts which use the following directive within the source code can be affected:
 
@@ -60,7 +60,7 @@ If you have deployed contracts which use the experimental ABI encoder V2, then t
 
 Additionally, there are a number of requirements for the bug to trigger. See technical details further below for more information.
 
-## How to check if contract is vulnerable
+### How to check if contract is vulnerable
 
 The bug only manifests itself when all of the following conditions are met:
 
@@ -71,13 +71,13 @@ In addition to that, in the following situation, your code is NOT affected:
 
 - if you only return such data and do not use it in `abi.encode`, external calls or event data.
 
-## Possible consequences
+### Possible consequences
 
 Naturally, any bug can have wildly varying consequences depending on the program control flow, but we expect that this is more likely to lead to malfunction than exploitability.
 
 The bug, when triggered, will under certain circumstances send corrupt parameters on method invocations to other contracts.
 
-## Technical details
+### Technical details
 
 During the encoding process, the experimental ABI encoder does not properly advance to the next element in an array in case the elements occupy more than a single slot in storage.
 

--- a/src/posts/2023-11-30-solidity-summit-2023-recap.md
+++ b/src/posts/2023-11-30-solidity-summit-2023-recap.md
@@ -7,8 +7,6 @@ author: Solidity Team
 category: Announcements
 ---
 
-# Solidity Summit 2023 Recap
-
 We can't believe it's already been two weeks since we met in Istanbul, Türkiye, for the third edition of Solidity Summit!
 
 Solidity Summit 2023 was part of the [Devconnect week](https://devconnect.org/) and took place on Thursday, November 16, 2023. With roughly 300 participants, the event was well attended.


### PR DESCRIPTION
## Description
- The `title` front matter prop is automatically rendered as the `<h1>` for page, and should be the only `h1` present in the DOM.
- This PR removes the redundant `h1` from the latest blog post, and updates older blog posts where additional `h1` elements were being used (adjusting the surrounding heading levels to follow proper syntax tree formatting