### PR TITLE
Update Copyright Year in Footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,7 +44,7 @@ export const Footer: React.FC = () => (
       </Flex>
     </Flex>
     <Flex fontSize="lg" textAlign="center" flexWrap="wrap" columnGap={4}>
-      <Text>2023 Solidity Team</Text>
+      <Text>2024 Solidity Team</Text>
       <Text>•</Text>
       <Link href="https://github.com/ethereum/solidity/blob/develop/SECURITY.md" color="primary">
         Security Policy

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,7 +44,7 @@ export const Footer: React.FC = () => (
       </Flex>
     </Flex>
     <Flex fontSize="lg" textAlign="center" flexWrap="wrap" columnGap={4}>
-      <Text>2024 Solidity Team</Text>
+      <Text>{new Date().getFullYear()} Solidity Team</Text>
       <Text>•</Text>
       <Link href="https://github.com/ethereum/solidity/blob/develop/SECURITY.md" color="primary">
         Security Policy


### PR DESCRIPTION
I noticed the website footer had 2023 as the copyright year, so here is a simple PR to update it to 2024.