### PR TITLE
Update index.tsx to display latest release: v0.8.26

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -115,12 +115,12 @@ export default function Home({
               <Box>
                 <Text lineHeight="180%" fontSize="md" mb={4}>
                   <Link
-                    href="/blog/2024/03/14/solidity-0.8.25-release-announcement/"
+                    href="/blog/2024/05/21/solidity-0.8.26-release-announcement/"
                     fontWeight="bold"
                   >
-                    Solidity 0.8.25
+                    Solidity 0.8.26
                   </Link>{' '}
-                  Introducing the newest version of the Solidity Compiler: v0.8.25. This is a minor release following the Dencun hard-fork on Ethereum mainnet that occurred on March 13, 2024 at 13:55 UTC.
+                  Introducing the newest version of the Solidity Compiler: v0.8.26. This is a minor release following the Dencun hard-fork on Ethereum mainnet that occurred on March 13, 2024 at 13:55 UTC.
                 </Text>
               </Box>
             </Flex>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -120,7 +120,7 @@ export default function Home({
                   >
                     Solidity 0.8.26
                   </Link>{' '}
-                  Introducing the newest version of the Solidity Compiler: v0.8.26. This is a minor release following the Dencun hard-fork on Ethereum mainnet that occurred on March 13, 2024 at 13:55 UTC.
+                  Introducing the newest version of the Solidity Compiler: v0.8.26. This newest version of the compiler brings support for custom errors in require, improved default Yul Optimizer sequence that will speed up compilation via IR, several bugfixes, and more!
                 </Text>
               </Box>
             </Flex>


### PR DESCRIPTION
![CleanShot 2024-06-03 at 13 33 58 on Arc — Comparing ethereummain zarifpourmain · ethereumsolidity-website](https://github.com/ethereum/solidity-website/assets/16494335/d2989513-a006-45d1-b0db-4906e873a494)

---

Updated to display and link to [Solidity 0.8.26](https://soliditylang.org/blog/2024/05/21/solidity-0.8.26-release-announcement).