### PR TITLE
fix: 404's links

### DIFF
--- a/src/posts/2021-02-01-launching-the-solidity-forum.md
+++ b/src/posts/2021-02-01-launching-the-solidity-forum.md
@@ -50,7 +50,7 @@ Examples of topics that could fit the Language Design category:
 - "Change the way inheritance works"
 - "Introduce a `switch` statement"
 
-ℹ️ You can follow the implementation status of new features in the [Solidity Github project](https://github.com/ethereum/solidity/projects/43). Issues in the design backlog need further specification and will either be discussed in a language design call or in a regular team call. You can see the upcoming changes for the next breaking release by changing from the default branch (develop) to the [breaking branch](https://github.com/ethereum/solidity/tree/breaking).
+ℹ️ You can follow the implementation status of new features in the [Solidity Github project](https://github.com/orgs/ethereum/projects/17). Issues in the design backlog need further specification and will either be discussed in a language design call or in a regular team call. You can see the upcoming changes for the next breaking release by changing from the default branch (develop) to the [breaking branch](https://github.com/ethereum/solidity/tree/breaking).
 
 #### → Tools & Infrastructure
 

--- a/src/posts/2021-02-15-contributing-to-solidity-101.md
+++ b/src/posts/2021-02-15-contributing-to-solidity-101.md
@@ -77,7 +77,7 @@ In addition to the forum and issue discussions, we regularly host language desig
 
 We are also sharing feedback surveys and other language design relevant content in the forum.
 
-If you want to know where the team is standing in terms or implementing new features, you can follow the implementation status in the [Solidity Github project](https://github.com/ethereum/solidity/projects/43). Issues in the `design backlog` need further specification and will either be discussed in a language design call or in a regular team call. You can see the upcoming changes for the next breaking release by changing from the default branch (develop) to the [breaking branch](https://github.com/ethereum/solidity/tree/breaking).
+If you want to know where the team is standing in terms of implementing new features, you can follow the implementation status in the [Solidity Github project](https://github.com/orgs/ethereum/projects/17). Issues in the `design backlog` need further specification and will either be discussed in a language design call or in a regular team call. You can see the upcoming changes for the next breaking release by changing from the default branch (develop) to the [breaking branch](https://github.com/ethereum/solidity/tree/breaking).
 
 ### Get Involved Now!
 


### PR DESCRIPTION
## Description
I identified and updated broken links in two Markdown files within the repository:

1. **`2021-02-01-launching-the-solidity-forum.md`**  
   - Updated the link to the correct Solidity GitHub project page:  
     - From: `https://github.com/ethereum/solidity/projects/43`  
     - To: `https://github.com/orgs/ethereum/projects/17`

2. **`2021-02-15-contributing-to-solidity-101.md`**  
   - Updated the link to the same corrected GitHub project page.