### PR TITLE
Bump deploy-pages to v4

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -94,4 +94,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Same as #127 but bumping deploy-pages action to v4: https://github.com/ethereum/solidity-website/actions/runs/13814223102