### PR TITLE
Address 0.8.29 release concerns

### DIFF
--- a/src/posts/2025-03-12-solidity-0.8.29-release-announcement.md
+++ b/src/posts/2025-03-12-solidity-0.8.29-release-announcement.md
@@ -7,7 +7,7 @@ category: Releases
 
 We are excited to announce the release of the Solidity Compiler [v0.8.29](https://github.com/ethereum/solidity/releases/tag/v0.8.29).
 
-This latest version of the compiler brings experimental support for EVM Object Format, support for custom storage layouts, initial supoort for ethdebug, and more! 
+This latest version of the compiler brings experimental support for EVM Object Format, support for custom storage layouts, initial supoort for ethdebug, and more!
 
 ## Notable Features
 
@@ -19,6 +19,8 @@ Please note that the feature can only be enabled when compiling for the Osaka EV
 The experimental backend is still incomplete and implements only a subset of EOF features.
 This subset, however, is already sufficient to support compiling arbitrary Solidity contracts.
 The missing elements are, for the most part, opcodes like `RJUMPV` or `EXCHANGE`, which will let us generate more efficient code in the future, but were not strictly necessary to be able to generate working bytecode.
+
+A major benefit that the prototype already provides is the access to `SWAPN` and `DUPN` opcodes, which extend the accessible portion of the stack from 16 to 256 slots and virtually eliminate the "Stack Too Deep" errors in practical scenarios.
 
 Note that existing contracts may not compile without adjustments, due to some features no longer existing on EOF.
 For example, gas and code introspection are no longer possible, which means that it is impossible to generate code for the `gas` call option on external calls or builtins like `gasleft()` and `<address>.code`.

--- a/src/posts/2025-03-12-solidity-0.8.29-release-announcement.md
+++ b/src/posts/2025-03-12-solidity-0.8.29-release-announcement.md
@@ -30,8 +30,11 @@ The `salt` has a default value (`0`), but will soon become mandatory, since usin
 Finally, many opcodes were removed or replaced, in particular the external calls, so contracts making heavy use of inline assembly will likely not compile as-is.
 
 Due to the experimental nature of the feature, not all of the syntax differences are covered by analysis checks at the moment and in certain cases you may encounter internal compiler errors when attempting to use them.
-Please bear with us, and note that these should not be reported as bugs in the implementation.
-They will be addressed in subsequent releases.
+Some of the non-EOF builtins may also still compile, simply ignoring the EOF-specific part.
+For example the `send()` and `transfer()` builtins have not yet been removed, despite the fact that they can no longer be correctly implemented due to the removal of the gas parameter from the call opcodes.
+What we are releasing is only an initial, experimental version with many rough edges, meant to elicit early feedback from the community.
+We are aware of these shortcomings and there is no need to report them as bugs in the implementation at this point.
+You can track progress of the ongoing work by watching the issue in our bug tracker: [#15310](https://github.com/ethereum/solidity/issues/15310).
 
 Furthermore, compilation to EOF can only be performed via IR and only with the optimiser enabled.
 The current implementation, however, does not include any low-level optimisations, which may lead to increased code size in some cases.


### PR DESCRIPTION
- The concerns about missing checks on `.send()`/`.transfer()`.
- I also realized that we did not mention StackTooDeep and that's something of high interest to users.