### PR TITLE
Update constants.ts: fixed 404 error for DAO link by inluding i18n en…

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -261,7 +261,7 @@ export const USE_CASES: UseCase[] = [
     description:
       'Solidity has enabled the creation of DAOs, which are self-governing organizations that operate on smart contracts, allowing for transparent decision-making and governance.',
     imageSrc: '/assets/use-case-glyph-3.svg',
-    learnMoreLink: `${ETHEREUM_ORG_URL}/dao`,
+    learnMoreLink: `${ETHEREUM_ORG_URL}/en/dao`,
     triangleVariant: 'heap',
     mobileTriangleVariant: 'mobileHeap',
   },


### PR DESCRIPTION
… path in link

On this screen: https://soliditylang.org/use-cases/ the "Learn more" link under Decentralised Autonomous Orgs points to:
- https://ethereum.org/dao/
- instead it should point to https://ethereum.org/en/dao/

This PR fixes this.