### PR TITLE
chore(ci): upgrade checkout to v4

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Detect package manager
         id: detect-package-manager
         run: |


### PR DESCRIPTION
GitHub-hosted runners now use Node 20, so actions/checkout@v4 is required. Workflows only updated—no functional changes.