### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
           cache: ${{ steps.detect-package-manager.outputs.manager }}


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0