### PR TITLE
Migrate to Next.js static export for GitHub Pages deployment

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -73,16 +73,14 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-      - name: Build with Next.js
+      - name: Build and static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
         env:
           GITHUB_TOKEN_READ_ONLY: ${{ secrets.TOKEN_READ_ONLY }}
-      - name: Static HTML export with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export -o docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          path: ./docs
+          path: ./out
 
   # Deployment job
   deploy:

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: 'standalone',
+  output: 'export',
   experimental: { esmExternals: true },
   trailingSlash: true,
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
   "private": false,
   "scripts": {
     "dev": "next dev",
-    "build": "yarn lint && yarn format && npx next build && yarn export",
+    "build": "yarn lint && yarn format && npx next build",
     "postbuild": "next-sitemap",
-    "start": "next start",
+    "start": "npx serve out",
     "lint": "next lint",
-    "format": "prettier --write .",
-    "export": "next export -o docs"
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.0.17",


### PR DESCRIPTION
Replace deprecated `next export` command with `output: 'export'` config.
This fixes CI failures after GitHub Actions version updates. See: https://github.com/argotorg/solidity-website/actions/runs/19903057389/job/57051955864