### PR TITLE
Remove configure-pages static_site_generator option

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -55,12 +55,6 @@ jobs:
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
       - name: Restore cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:


### PR DESCRIPTION
After we merged https://github.com/argotorg/solidity-website/pull/168, the next.config.js already contains output: 'export' configured. Letting the action inject config causes [TypeError](https://github.com/argotorg/solidity-website/actions/runs/19904482889/job/57057002347) with next-remove-imports wrapper.

See https://github.com/actions/configure-pages/issues/107#issuecomment-2266364526